### PR TITLE
バグ改修完了しました

### DIFF
--- a/src/main/java/jp/co/seattle/library/controller/AddBooksController.java
+++ b/src/main/java/jp/co/seattle/library/controller/AddBooksController.java
@@ -143,7 +143,6 @@ public class AddBooksController {
 
     } catch (DataIntegrityViolationException e) {
         model.addAttribute("error", " 256文字以上は登録できません");
-        //        return "details";
     }
 
         // TODO 登録した書籍の詳細情報を表示するように実装

--- a/src/main/java/jp/co/seattle/library/controller/AddBooksController.java
+++ b/src/main/java/jp/co/seattle/library/controller/AddBooksController.java
@@ -8,6 +8,7 @@ import java.util.Locale;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.stereotype.Controller;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.ui.Model;
@@ -71,7 +72,19 @@ public class AddBooksController {
         bookInfo.setDescription(description);
         bookInfo.setPublisher(publisher);
         bookInfo.setPublishDate(publishDate);
-        bookInfo.setIsbn(isbn);
+
+        //isbnに値が入ってなかったらnullを表示
+        if (isbn.isEmpty()) {
+            bookInfo.setIsbn(null);
+        } else {
+            bookInfo.setIsbn(isbn);
+        }
+
+        if (description.isEmpty()) {
+            bookInfo.setDescription(null);
+        } else {
+            bookInfo.setDescription(description);
+        }
 
         // クライアントのファイルシステムにある元のファイル名を設定する
         String thumbnail = file.getOriginalFilename();
@@ -94,12 +107,13 @@ public class AddBooksController {
                 return "addBook";
             }
         }
-        
+
         if (StringUtils.isNullOrEmpty(title) || StringUtils.isNullOrEmpty(author)
                 || StringUtils.isNullOrEmpty(publisher) || StringUtils.isNullOrEmpty(publishDate)) {
             model.addAttribute("error", "必須項目を入力してください");
             return "addBook";
         }
+
 
         try {
             DateFormat df = new SimpleDateFormat("yyyyMMdd");
@@ -119,11 +133,18 @@ public class AddBooksController {
                      }
 
         // 書籍情報を新規登録する
+        try {
         booksService.registBook(bookInfo);
         int bookMaxId = booksService.getBookId();
         model.addAttribute("lendingStatus", "貸出可");
         model.addAttribute("resultMessage", "登録完了");
         model.addAttribute("bookDetailsInfo", booksService.getBookInfo(bookMaxId));
+
+
+    } catch (DataIntegrityViolationException e) {
+        model.addAttribute("error", " 256文字以上は登録できません");
+        //        return "details";
+    }
 
         // TODO 登録した書籍の詳細情報を表示するように実装
 

--- a/src/main/java/jp/co/seattle/library/controller/BulkBookController.java
+++ b/src/main/java/jp/co/seattle/library/controller/BulkBookController.java
@@ -98,11 +98,12 @@ public class BulkBookController {
                     errorlist.add(number + "行目のISBNの桁数または半角数字が正しくありません");
                 }
             }
-                //エラーメッセージの表示
-                if (!(errorlist.size() == 0)) {
-                    model.addAttribute("errorlist", errorlist);
-                    return "bulkBook";
-                }
+            //エラーメッセージの表示
+            if (!(errorlist.size() == 0)) {
+                model.addAttribute("errorlist", errorlist);
+                return "bulkBook";
+            }
+
 
             for (int i = 0; i < booklist.size(); i++) {
                 BookDetailsInfo bookInfo = new BookDetailsInfo();
@@ -117,6 +118,9 @@ public class BulkBookController {
             }
         } catch (IOException e) {
             e.printStackTrace();
+        } catch (ArrayIndexOutOfBoundsException e) {
+            model.addAttribute("errorlist", "256文字以上のcsvファイルは登録できません");
+            return "bulkBook";
         }
         model.addAttribute("resultMessage", "登録完了");
 

--- a/src/main/java/jp/co/seattle/library/controller/BulkBookController.java
+++ b/src/main/java/jp/co/seattle/library/controller/BulkBookController.java
@@ -99,7 +99,7 @@ public class BulkBookController {
                 }
             }
             //エラーメッセージの表示
-            if (!(errorlist.size() == 0)) {
+            if (errorlist.size() > 0) {
                 model.addAttribute("errorlist", errorlist);
                 return "bulkBook";
             }

--- a/src/main/java/jp/co/seattle/library/controller/EditBookController.java
+++ b/src/main/java/jp/co/seattle/library/controller/EditBookController.java
@@ -8,6 +8,7 @@ import java.util.Locale;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.stereotype.Controller;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.ui.Model;
@@ -15,8 +16,6 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.multipart.MultipartFile;
-
-import com.mysql.jdbc.StringUtils;
 
 import jp.co.seattle.library.dto.BookDetailsInfo;
 import jp.co.seattle.library.service.BooksService;
@@ -114,12 +113,12 @@ public class EditBookController {
                 return "editBook";
             }
         }
-
-        if (StringUtils.isNullOrEmpty(title) || StringUtils.isNullOrEmpty(author)
-                || StringUtils.isNullOrEmpty(publisher) || StringUtils.isNullOrEmpty(publishDate)) {
-            model.addAttribute("error", "必須項目を入力してください");
-            return "editBook";
-        }
+        //
+        //        if (StringUtils.isNullOrEmpty(title) || StringUtils.isNullOrEmpty(author)
+        //                || StringUtils.isNullOrEmpty(publisher) || StringUtils.isNullOrEmpty(publishDate)) {
+        //            model.addAttribute("error", "必須項目を入力してください");
+        //            return "editBook";
+        //        }
 
         try {
             DateFormat df = new SimpleDateFormat("yyyyMMdd");
@@ -138,7 +137,10 @@ public class EditBookController {
             return "editBook";
         }
 
+
         // 書籍情報を新規登録する
+
+        try {
         booksService.editBook(bookInfo);
 
         int number = rentService.rentCount(bookId);
@@ -151,6 +153,9 @@ public class EditBookController {
         }
 
         model.addAttribute("bookDetailsInfo", booksService.getBookInfo(bookId));
+    } catch (DataIntegrityViolationException e) {
+        model.addAttribute("error", " 256文字以上は登録できません");
+    }
         //  詳細画面に遷移する
         return "details";
     }

--- a/src/main/java/jp/co/seattle/library/controller/EditBookController.java
+++ b/src/main/java/jp/co/seattle/library/controller/EditBookController.java
@@ -113,12 +113,6 @@ public class EditBookController {
                 return "editBook";
             }
         }
-        //
-        //        if (StringUtils.isNullOrEmpty(title) || StringUtils.isNullOrEmpty(author)
-        //                || StringUtils.isNullOrEmpty(publisher) || StringUtils.isNullOrEmpty(publishDate)) {
-        //            model.addAttribute("error", "必須項目を入力してください");
-        //            return "editBook";
-        //        }
 
         try {
             DateFormat df = new SimpleDateFormat("yyyyMMdd");

--- a/src/main/webapp/WEB-INF/views/addBook.jsp
+++ b/src/main/webapp/WEB-INF/views/addBook.jsp
@@ -56,26 +56,26 @@
                     <div>
                         <span>書籍名</span><span class="care care2">必須</span>
                         <c:if test="${empty bookInfo}">
-                            <input type="text" name="title" autocomplete="off">
+                            <input type="text" name="title" autocomplete="off" required>
                         </c:if>
                     </div>
                     <div>
                         <span>著者名</span><span class="care care2">必須</span>
                         <c:if test="${empty bookInfo}">
-                            <input type="text" name="author" autocomplete="off">
+                            <input type="text" name="author" autocomplete="off" required>
                         </c:if>
                     </div>
                     <div>
                         <span>出版社</span><span class="care care2">必須</span>
                         <c:if test="${empty bookInfo}">
-                            <input type="text" name="publisher">
+                            <input type="text" name="publisher" required>
                         </c:if>
                     </div>
                     <div>
                         <span>出版日</span><span class="care care2">必須</span>
                         <c:if test="${empty bookInfo}">
                         
-                            <input type="text" name="publish_date">
+                            <input type="text" name="publish_date" required>
                         </c:if>  
                     </div>
                     <div>

--- a/src/main/webapp/WEB-INF/views/details.jsp
+++ b/src/main/webapp/WEB-INF/views/details.jsp
@@ -66,11 +66,21 @@
                 </div>
                 <div>
                     <span>ISBN</span>
+                    <c:if test="${bookDetailsInfo.isbn == 'null'}">
+                    <p> </p>
+                    </c:if>
+                    <c:if test="${bookDetailsInfo.isbn != 'null'}">
                     <p>${bookDetailsInfo.isbn}</p>
+                    </c:if>
                 </div>
                 <div>
                     <span>説明文</span>
+                    <c:if test="${bookDetailsInfo.description == 'null'}">
+                    <p> </p>
+                    </c:if>
+                    <c:if test="${bookDetailsInfo.description != 'null'}">
                     <p>${bookDetailsInfo.description}</p>
+                    </c:if>
                 </div>
             </div>
         </div>

--- a/src/main/webapp/WEB-INF/views/editBook.jsp
+++ b/src/main/webapp/WEB-INF/views/editBook.jsp
@@ -54,55 +54,55 @@
                     <div>
                         <span>書籍名</span><span class="care care2">必須</span>
                         <c:if test = "${!empty bookDetailsInfo}">
-                            <input type = "text" name = "title" value = "${bookDetailsInfo.title}"> 
+                            <input type = "text" name = "title" value = "${bookDetailsInfo.title}" required> 
                         </c:if>
                         <c:if test="${empty bookDetailsInfo}">
-                            <input type="text" name="title" autocomplete="off">
+                            <input type="text" name="title" autocomplete="off" required>
                         </c:if>
                     </div>
                     <div>
                         <span>著者名</span><span class="care care2">必須</span>
                          <c:if test = "${!empty bookDetailsInfo}">
-                            <input type = "text" name = "author" value = "${bookDetailsInfo.author}"> 
+                            <input type = "text" name = "author" value = "${bookDetailsInfo.author}" required> 
                         </c:if>
                         <c:if test="${empty bookDetailsInfo}">
-                            <input type="text" name="author" autocomplete="off">
+                            <input type="text" name="author" autocomplete="off" required>
                         </c:if>
                     </div>
                     <div>
                         <span>出版社</span><span class="care care2">必須</span>
                          <c:if test = "${!empty bookDetailsInfo}">
-                            <input type = "text" name = "publisher" value = "${bookDetailsInfo.publisher}"> 
+                            <input type = "text" name = "publisher" value = "${bookDetailsInfo.publisher}" required> 
                         </c:if>
                         <c:if test="${empty bookDetailsInfo}">
-                            <input type="text" name="publisher">
+                            <input type="text" name="publisher" required>
                         </c:if>
                     </div>
                     <div>
                         <span>出版日</span><span class="care care2">必須</span>
                          <c:if test = "${!empty bookDetailsInfo}">
-                            <input type = "text" name = "publish_date" value = "${bookDetailsInfo.publishDate}"> 
+                            <input type = "text" name = "publish_date" value = "${bookDetailsInfo.publishDate}"required> 
                         </c:if>
                         <c:if test="${empty bookDetailsInfo}">
-                            <input type="text" name="publish_date">
+                            <input type="text" name="publish_date"required>
                         </c:if>  
                     </div>
                     <div>
                         <span>ISBN</span><span class="care care1">任意</span>
                          <c:if test = "${!empty bookDetailsInfo}">
-                            <input type = "text" name = "isbn" value = "${bookDetailsInfo.isbn}"> 
+                            <input type = "text" name = "isbn" value = "${bookDetailsInfo.isbn}" required> 
                         </c:if>
                         <c:if test="${empty bookDetailsInfo}">
-                            <input type="text" name="isbn">
+                            <input type="text" name="isbn" required>
                         </c:if>
                     </div>
                     <div>
                         <span>説明文</span><span class="care care1">任意</span>
                          <c:if test = "${!empty bookDetailsInfo}">
-                            <input type = "text" name = "description" value = "${bookDetailsInfo.description}"> 
+                            <input type = "text" name = "description" value = "${bookDetailsInfo.description}" required> 
                         </c:if>
                         <c:if test="${empty bookDetailsInfo}">
-                            <input type="text" name="description">
+                            <input type="text" name="description" required>
                         </c:if>
                     </div>
                     <input type="hidden" id="bookId" name="bookId" value="${bookDetailsInfo.bookId}">

--- a/src/main/webapp/resources/css/home.css
+++ b/src/main/webapp/resources/css/home.css
@@ -141,14 +141,23 @@
 	.book_title {
 		font-size: 20px;
 		text-align: center;
+		white-space: nowrap;
+		overflow: hidden;
+		    width: 200px;
 	}
 	.book_author {
 		font-size: 13px;
 		text-align: center;
 		margin-bottom: 20px;
+		white-space: nowrap;
+		overflow: hidden;
+		    width: 200px;
 	}
 	.book_publisher, .book_publish_date {
 		font-size: 12px;
+		white-space: nowrap;
+		overflow: hidden;
+		    width: 200px;
 	}
 	button.btn_addBook, button.btn_editBook, button.btn_deleteBook, button.btn_rentBook,
 		button.btn_returnBook, button.btn_bulkRegist {
@@ -356,12 +365,15 @@
 		border-bottom: 1px solid #cccccc;
 		margin: 5px 0 15px;
 		font-size: 17px;
+		
 	}
 	.detail_book_content .content_left {
 		width: 250px;
 	}
 	.detail_book_content .content_right {
 		width: 275px;
+		white-space: nowrap;
+		overflow: hidden;
 	}
 	.detail_book_content .content_right p {
 		padding: 5px 0;


### PR DESCRIPTION
・追加、編集、一括登録画面で256文字以上の追加、編集、一括画面それぞれで登録する。
・追加、編集する際に必須項目に値を入れ忘れた場合、今までの書籍データが画面上で消えないようにする。
・詳細画面で、下線からはみでないようにする。
・MYSQLのISBNと説明のカラムにNULLが入るようにする。
以上に関して修正しました。ご確認お願いします。